### PR TITLE
Chore/increase test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+
+exclude_lines =
+    if __name__ == .__main__.:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [tool:pytest]
-addopts = --cov=twitter_cleanup --cov-report term
+addopts = --cov=twitter_cleanup --cov-report term-missing
 python_files = tests/*.py

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from twitter_cleanup.__main__ import cli
+
+
+def test_command_bots(mocker):
+    cleaner = mocker.patch("twitter_cleanup.__main__.TwitterCleanup").return_value
+    runner = CliRunner()
+    result = runner.invoke(cli, ["bots"])
+    assert result.exit_code == 0
+    cleaner.soft_block_bots.assert_called_once()
+
+
+def test_command_bots_with_wrong_too_high_argument(mocker):
+    mocker.patch("twitter_cleanup.__main__.TwitterCleanup")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["bots", "101"])
+    assert result.exit_code == 2
+
+
+def test_command_bots_with_wrong_too_low_argument(mocker):
+    mocker.patch("twitter_cleanup.__main__.TwitterCleanup")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["bots", "-1"])
+    assert result.exit_code == 2
+
+
+def test_command_inactive(mocker):
+    cleaner = mocker.patch("twitter_cleanup.__main__.TwitterCleanup").return_value
+    runner = CliRunner()
+    result = runner.invoke(cli, ["inactive", "123"])
+    assert result.exit_code == 0
+    cleaner.unfollow_inactive_for.assert_called_once_with(days=123)
+
+
+def test_command_clear_cache(mocker):
+    mocker.patch("twitter_cleanup.__main__.TwitterCleanup")
+    path = mocker.patch("twitter_cleanup.__main__.Path").return_value
+    file = mocker.Mock()
+    path.glob.return_value = [file]
+    runner = CliRunner()
+    result = runner.invoke(cli, ["clear-cache"])
+    assert result.exit_code == 0
+    file.unlink.assert_called_once()
+
+    file2 = mocker.Mock()
+    path.glob.return_value = [file2, file2, file2]
+    runner.invoke(cli, ["clear-cache"])
+    assert 3 == file2.unlink.call_count


### PR DESCRIPTION
Hey,
I would like to increase the test coverage for this project.
Here are some first steps:
- tests for click interface (100% ;-) )
- some changes to the tests launch command to show missed lines
- changes for the coverage config to ignore obvious ` if __name__ == "__main__":` lines

The report:
```Name                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------
twitter_cleanup/__init__.py            75     40    47%   44-45, 50-51, 57-76, 80-84, 89-108, 114, 124
twitter_cleanup/__main__.py            21      0   100%
twitter_cleanup/authentication.py      22     13    41%   15-17, 20-25, 30-32, 37
twitter_cleanup/botometer.py           37     22    41%   22-29, 32, 37-43, 47-57
twitter_cleanup/cache.py               73     59    19%   9-20, 23-38, 41-61, 64-70, 73-76, 79-81, 84-88, 91-92, 95-98
twitter_cleanup/user.py                18      5    72%   19, 31-35
-----------------------------------------------------------------
TOTAL                                 246    139    43%
```